### PR TITLE
Change from os-conf test release to zookeeper-release

### DIFF
--- a/fixtures/small-deployment.yml
+++ b/fixtures/small-deployment.yml
@@ -2,10 +2,11 @@
 name: small-deployment
 
 releases:
-- name: "os-conf"
-  version: "21.0.0"
-  url: "https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=21.0.0"
-  sha1: "7579a96515b265c6d828924bf4f5fae115798199"
+- name: "zookeeper"
+  version: "0.0.10"
+  url: "https://bosh.io/d/github.com/cppforlife/zookeeper-release?v=0.0.10"
+  sha1: "a6d227abceebf1e3e68ce4a3cabf68b0b93165d2"
+
 
 stemcells:
 - alias: default
@@ -20,12 +21,12 @@ update:
 
 instance_groups:
 - name: small-job
+  azs: [((az_name))]
+  instances: 1
+  jobs:
+    - name: zookeeper
+      release: zookeeper
   stemcell: default
   vm_type: ((vm_type))
-  instances: 1
   networks:
-  - {name: ((network_name))}
-  azs: [((az_name))]
-  jobs:
-  - name: monit
-    release: os-conf
+    - {name: ((network_name))}


### PR DESCRIPTION
The BOSH team made changes to the CLI to enhance the information
reported by commands such as `bosh vms`, and this broke one of the bosh
disaster recovery acceptance tests. This is due to a new status being
reported when there are no processes running on the VM. Since to better
validate the test scenario that broke we require a VM with running
processes, we changed the test release to a release that include running
jobs (zookeeper-release).

[#167575114](https://www.pivotaltracker.com/story/show/167575114)

Co-authored-by: Maya Rosecrance <mrosecrance@pivotal.io>

Thanks for submitting a PR to B-DRATS.

## Checklist

Please provide the following information:

- [X] What component are you testing?
  No changes in the test suite.

- [X] Have you created a `TestCase` and added it to the list of cases to be run?
  No tests added

- [X] Have you added an `include_<testcase-name>` property and any other new properties to the sample integration_config.json in the README?
  N/A

- [X] Have you manually validated your `TestCase` against a deployed BOSH? If so, which version?
  we ran the tests locally against 270.3.0

- [X] Does this change rely on a particular version of a release?
  The changes replace the `os-conf` for `zookeeper-release`

- [X] Are you available for a cross-team pair to help troubleshoot your PR?
  Yes, the BOSH team is available to Xtp if the need arises

- [X] Have you submitted a pull request to modify the bosh-deployment [backup and restore opsfile](https://github.com/cloudfoundry/bosh-deployment/blob/master/bbr.yml) to add a backup job and properties where appropriate?
   N/A

### Do you have any other useful information for us?
This thread: https://app.slack.com/client/T024LQKAS/C1NUHQ3BK/thread/C1NUHQ3BK-1564185173.021000

We're on the #bbr cloudfoundry Slack channel if you need us.