### PR TITLE
Test will retry if sdk instances are not yet running

### DIFF
--- a/testcases/deployment_testcase.go
+++ b/testcases/deployment_testcase.go
@@ -85,15 +85,20 @@ func (t DeploymentTestcase) AfterRestore(config Config) {
 	})
 
 	By("validate deployment instances are back", func() {
-		session := RunBoshCommandSuccessfullyWithFailureMessage("bosh get sdk instances",
-			config,
-			"-n",
-			"-d",
-			"small-deployment",
-			"instances",
-		)
-		Expect(string(session.Out.Contents())).To(MatchRegexp("small-job/[a-z0-9-]+[ \t]+running"))
+
+		Eventually(getInstances("small-deployment", config)).Should(MatchRegexp("small-job/[a-z0-9-]+[ \t]+running"))
 	})
+}
+
+func getInstances(deployment string, config Config) string {
+	session := RunBoshCommandSuccessfullyWithFailureMessage("bosh get sdk instances",
+		config,
+		"-n",
+		"-d",
+		deployment,
+		"instances",
+	)
+	return string(session.Out.Contents())
 }
 
 func (t DeploymentTestcase) Cleanup(config Config) {

--- a/testcases/deployment_testcase.go
+++ b/testcases/deployment_testcase.go
@@ -2,6 +2,8 @@ package testcases
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/cloudfoundry-incubator/bosh-disaster-recovery-acceptance-tests/fixtures"
 	. "github.com/cloudfoundry-incubator/bosh-disaster-recovery-acceptance-tests/runner"
@@ -86,7 +88,19 @@ func (t DeploymentTestcase) AfterRestore(config Config) {
 
 	By("validate deployment instances are back", func() {
 
-		Eventually(getInstances("small-deployment", config)).Should(MatchRegexp("small-job/[a-z0-9-]+[ \t]+running"))
+		instanceState := getInstances("small-deployment", config)
+
+		retries := 0
+		for retries < 3{
+			if strings.Contains(instanceState, "running"){
+				break
+			} else {
+				retries += 1
+				time.Sleep(time.Duration(retries * 10) * time.Second)
+			}
+		}
+
+		Expect(instanceState).To(MatchRegexp("small-job/[a-z0-9-]+[ \t]+running"))
 	})
 }
 


### PR DESCRIPTION
This PR changes the logic to allow more time for the sdk instances to be in a running state. Previously the test failed if the instances were starting when the check was performed.

[#177209174]
