### PR TITLE
Update for bionic stemcells

### DIFF
--- a/ci/pipelines/b-drats/pipeline.yml
+++ b/ci/pipelines/b-drats/pipeline.yml
@@ -60,7 +60,7 @@ resources:
 - name: gcs-stemcell
   type: bosh-io-stemcell
   source:
-    name: bosh-google-kvm-ubuntu-xenial-go_agent
+    name: bosh-google-kvm-ubuntu-bionic-go_agent
 
 - name: six-hours
   type: time

--- a/fixtures/small-deployment.yml
+++ b/fixtures/small-deployment.yml
@@ -10,7 +10,7 @@ releases:
 
 stemcells:
 - alias: default
-  os: ubuntu-xenial
+  os: ubuntu-bionic
   version: latest
 
 update:


### PR DESCRIPTION
The bosh team is updating the bosh director pipelines to use bionic stemcells rather than xenial since xenial is no longer supported in OSS.

This PR updates the stemcell from xenial to bionic. There is a change to the tests, as well as a change to your pipeline. It will need to be reflown as part of this.

