### PR TITLE
Replace PR resource

### DIFF
--- a/ci/pipelines/b-drats/pipeline.yml
+++ b/ci/pipelines/b-drats/pipeline.yml
@@ -8,7 +8,7 @@ resource_types:
 - name: pull-request
   type: docker-image
   source:
-    repository: jtarchie/pr
+    repository: teliaoss/github-pr-resource
     tag: latest
 
 - name: terraform
@@ -38,7 +38,7 @@ resources:
 - name: bosh-disaster-recovery-acceptance-tests-prs
   type: pull-request
   source:
-    repo: cloudfoundry-incubator/bosh-disaster-recovery-acceptance-tests
+    repository: cloudfoundry-incubator/bosh-disaster-recovery-acceptance-tests
     access_token: ((github.access_token))
 
 - name: bbr-binary-release


### PR DESCRIPTION
- This replaces jtarchie with teliaoss PR resource to fix errors in
  pulling the former from dockerhub

Signed-off-by: Neil Hickey <nhickey@vmware.com>

Thanks for submitting a PR to B-DRATS.

## Checklist

Please provide the following information:

- [ ] What component are you testing?
- [ ] Have you created a `TestCase` and added it to the list of cases to be run?
- [ ] Have you added an `include_<testcase-name>` property and any other new properties to the sample integration_config.json in the README?
- [ ] Have you manually validated your `TestCase` against a deployed BOSH? If so, which version?
- [ ] Does this change rely on a particular version of a release?
- [ ] Are you available for a cross-team pair to help troubleshoot your PR?
- [ ] Have you submitted a pull request to modify the bosh-deployment [backup and restore opsfile](https://github.com/cloudfoundry/bosh-deployment/blob/master/bbr.yml) to add a backup job and properties where appropriate?

### Do you have any other useful information for us?

We're on the #bbr cloudfoundry Slack channel if you need us.